### PR TITLE
fix: prevent Invalid Date for Calendarific astronomical events

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -14,9 +14,14 @@ export function toDateKey(date) {
 
 /**
  * Parse a YYYY-MM-DD key into a Date at local midnight.
+ *
+ * Tolerates date keys that carry a trailing time/timezone (e.g.
+ * "2026-06-21T08:24:00+08:00"), which some upstream APIs return for
+ * astronomical events, by reading only the leading calendar date.
  */
 export function parseDateKey(dateKey) {
-  const [year, month, day] = dateKey.split('-').map(Number);
+  const datePart = String(dateKey).split('T')[0];
+  const [year, month, day] = datePart.split('-').map(Number);
   return new Date(year, month - 1, day);
 }
 

--- a/src/utils/dateUtils.test.js
+++ b/src/utils/dateUtils.test.js
@@ -32,6 +32,16 @@ describe('parseDateKey', () => {
   it('round-trips with toDateKey', () => {
     expect(toDateKey(parseDateKey('2026-07-14'))).toBe('2026-07-14');
   });
+
+  it('reads only the calendar date when the key carries a time/timezone', () => {
+    // Calendarific returns ISO datetimes like this for solstices/equinoxes.
+    const date = parseDateKey('2026-06-21T08:24:00+08:00');
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(5);
+    expect(date.getDate()).toBe(21);
+    expect(Number.isNaN(date.getTime())).toBe(false);
+    expect(toDateKey(date)).toBe('2026-06-21');
+  });
 });
 
 describe('toMonthPrefix', () => {

--- a/worker/holidays.js
+++ b/worker/holidays.js
@@ -195,18 +195,28 @@ async function fetchFromCalendarific(year, countryCode, apiKey) {
     return [];
   }
 
-  return data.response.holidays.map(holiday => ({
-    id: `calendarific-${holiday.date.iso}-${holiday.name.replace(/\s+/g, '-').toLowerCase()}`,
-    name: holiday.name,
-    date: holiday.date.iso,
-    country: getCountryName(countryCode),
-    countryCode: countryCode,
-    type: Array.isArray(holiday.type) ? holiday.type.join(', ') : (holiday.type || 'unknown'),
-    source: 'calendarific',
-    description: holiday.description || `${holiday.name} is celebrated in ${getCountryName(countryCode)}.`,
-    primary_type: holiday.primary_type,
-    canonical_url: holiday.canonical_url
-  }));
+  return data.response.holidays.map(holiday => {
+    // Calendarific returns date.iso as a plain YYYY-MM-DD for most holidays,
+    // but for astronomical events (solstices, equinoxes) it includes a time
+    // and timezone, e.g. "2026-06-21T08:24:00+08:00". Keep only the calendar
+    // date so downstream YYYY-MM-DD parsing doesn't produce an Invalid Date.
+    const dateOnly = typeof holiday.date.iso === 'string'
+      ? holiday.date.iso.split('T')[0]
+      : holiday.date.iso;
+
+    return {
+      id: `calendarific-${dateOnly}-${holiday.name.replace(/\s+/g, '-').toLowerCase()}`,
+      name: holiday.name,
+      date: dateOnly,
+      country: getCountryName(countryCode),
+      countryCode: countryCode,
+      type: Array.isArray(holiday.type) ? holiday.type.join(', ') : (holiday.type || 'unknown'),
+      source: 'calendarific',
+      description: holiday.description || `${holiday.name} is celebrated in ${getCountryName(countryCode)}.`,
+      primary_type: holiday.primary_type,
+      canonical_url: holiday.canonical_url
+    };
+  });
 }
 
 async function getCulturalObservances(year, countryCode) {


### PR DESCRIPTION
Calendarific returns date.iso as a full ISO datetime with time and
timezone for solstices/equinoxes (e.g. 2026-06-21T08:24:00+08:00)
instead of a plain YYYY-MM-DD. The worker passed this through verbatim,
so parseDateKey produced NaN day components and the list view rendered
'Invalid Date'.

Normalize Calendarific dates to YYYY-MM-DD at the source, and harden
parseDateKey to read only the leading calendar date as defense-in-depth.